### PR TITLE
Potential fix for code scanning alert no. 2: Disabling certificate validation

### DIFF
--- a/actions-runner/bin/checkScripts/downloadCert.js
+++ b/actions-runner/bin/checkScripts/downloadCert.js
@@ -10,7 +10,7 @@ const proxyPort = process.env['PROXYPORT'] || ''
 const proxyUsername = process.env['PROXYUSERNAME'] || ''
 const proxyPassword = process.env['PROXYPASSWORD'] || ''
 
-process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0'
+
 
 if (proxyHost === '') {
     const options = {


### PR DESCRIPTION
Potential fix for [https://github.com/thejokers69/progress-bar/security/code-scanning/2](https://github.com/thejokers69/progress-bar/security/code-scanning/2)

To fix the problem, we need to ensure that certificate validation is not disabled. This involves removing or modifying the line that sets `process.env['NODE_TLS_REJECT_UNAUTHORIZED']` to '0'. Instead, we should handle any certificate issues by properly managing trusted certificates or using a custom certificate authority if necessary.

The single best way to fix the problem without changing existing functionality is to remove the line that disables certificate validation. This ensures that the default behavior of validating certificates is maintained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Remove the line that disables TLS certificate validation to address a security vulnerability

Bug Fixes:
- Removed the code that globally disabled TLS certificate validation, which was a significant security risk

Chores:
- Cleaned up security-related code to ensure proper certificate validation